### PR TITLE
Turn svmjs into an npm package

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ are in /test.
 
 ## Online GUI demo
 
-Can be found here: http://cs.stanford.edu/~karpathy/svmjs/demo/ 
+Can be found here: http://cs.stanford.edu/~karpathy/svmjs/demo/
 
 Corresponding code is inside /demo directory.
 
@@ -41,16 +41,16 @@ svm.train(data, labels, { kernel: svmjs.makeRbfKernel(0.5) }); // sigma = 0.5
 
 For linear kernels, you can also query the weights and offset directly:
 ```javascript
-wb= svm.getWeights(); 
+wb= svm.getWeights();
 //wb.w is array of weights and wb.b is the bias term
 ```
 
 For training you can pass in several options. Here are the defaults:
 ```javascript
 var options = {};
-/* For C, Higher = you trust your data more. Lower = more regularization. 
+/* For C, Higher = you trust your data more. Lower = more regularization.
 Should be in range of around 1e-2 ... 1e5 at most. */
-options.C = 1.0; 
+options.C = 1.0;
 options.tol = 1e-4; // do not touch this unless you're pro
 options.maxiter = 10000; // if you have a larger problem, you may need to increase this
 options.kernel = svmjs.linearKernel; // discussed above
@@ -58,16 +58,33 @@ options.numpasses = 10; // increase this for higher precision of the result. (bu
 svm.train(data, labels, options);
 ```
 
+## Using in node
+To use this library in [node.js](http://nodejs.org/), install with `npm`:
+
+```
+npm install svm
+```
+
+And use like so:
+
+```javascript
+var svm = require("svm");
+
+var SVM = new svm.SVM();
+
+SVM.train(data, labels);
+```
+
 ## Implementation details
-The SMO algorithm is very space efficient, so you need not worry about 
+The SMO algorithm is very space efficient, so you need not worry about
 running out of space no matter how large your problem is. However, you do need to
-worry about runtime efficiency. In practice, there are many heuristics one can 
+worry about runtime efficiency. In practice, there are many heuristics one can
 use to select the pair of alphas (i,j) to optimize and this uses a rather naive
 approach. If you have a large and complex problem, you will need to increase
 maxiter a lot. (or don't use Javascript!)
 
-If you intend to use only linear SVM and are worried about efficiency, I recommend 
-you train it, get the weights out with getWeights(), and use them directly in 
+If you intend to use only linear SVM and are worried about efficiency, I recommend
+you train it, get the weights out with getWeights(), and use them directly in
 your code from then on.
 
 ## License

--- a/lib/svm.js
+++ b/lib/svm.js
@@ -1,8 +1,8 @@
 // MIT License
 // Andrej Karpathy
 
-var svmjs = (function(){
-  
+var svmjs = (function(exports){
+
   /*
     This is a binary SVM and is trained using the SMO algorithm.
     Reference: "The Simplified SMO Algorithm" (http://math.unt.edu/~hsp0009/smo.pdf)
@@ -214,10 +214,10 @@ var svmjs = (function(){
   }
 
   // export public members
-  var exports = {};
+  exports = exports || {};
   exports.SVM = SVM;
   exports.makeRbfKernel = makeRbfKernel;
   exports.linearKernel = linearKernel;
   return exports;
-  
-})();
+
+})(typeof module != 'undefined' && module.exports);  // add exports to module.exports if in node.js

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "svm",
+  "description": "Support Vector Machines",
+  "version": "0.1.0",
+  "author": "Andrej Karpathy <andrej.karpathy@gmail.com>",
+  "main": "./lib/svm",
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/karpathy/svmjs.git"
+  },
+  "keywords": ["support vector machines", "machine learning", "classifier"]
+}


### PR DESCRIPTION
It would be awesome if people could consume this library from [node.js](http://nodejs.org). I'm sure a lot of node developers would love to play around with SVMs.

This PR does the necessary things to turn `svmjs` into a package that can be installed via [npm](https://npmjs.org/), node's package manager, which is bundled with node.

I changed the `svm.js` file so that it works both standalone in the browser, and if you imported it using `require('./svm')` from a file in the same directory, running in node.

I also added a `package.json` that will allow you to install svmjs as an npm package.

To get node.js people access to this, you'll need to publish the package to the npm registry. [Instructions on that are here](https://npmjs.org/doc/developers.html). Basically you'll need to create an npm account with `npm adduser`, then `npm publish` from the directory containing the `package.json` file.
