### PR TITLE
Allow passing in the kernel function to `fromJSON()`

### DIFF
--- a/lib/svm.js
+++ b/lib/svm.js
@@ -162,17 +162,16 @@ var svmjs = (function(exports){
     toJSON: function() {
       json = {}
       for(var i in this) {
-	if(typeof(this[i]) != 'function') {
+        if(typeof(this[i]) != 'function') {
           json[i] = this[i];
         }
       }
-      json.kernelName = 'svmjs.'+this.kernel.name;
       return json;
     },
     
-    fromJSON: function(json) {
-      json.kernel = eval(json.kernelName);
-      delete json.kernelName;
+    fromJSON: function(json, kernel) {
+      this.kernel = kernel || linearKernel;
+
       for(var i in json)
       {
         this[i] = json[i];

--- a/test/testnode.js
+++ b/test/testnode.js
@@ -1,0 +1,29 @@
+/* Run with `node testnode.js` */
+var assert = require("assert"),
+    svm = require("../lib/svm");
+
+var SVM = new svm.SVM();
+
+var options = {
+  kernel: svm.makeRbfKernel(0.5)
+}
+
+SVM.train([[0,0], [0,1], [1,0], [1,1]], [-1, 1, 1, -1], options);
+
+assert.equal(SVM.predict([[0,0]]), -1);
+assert.equal(SVM.predict([[0,1]]), 1);
+assert.equal(SVM.predict([[1,0]]), 1);
+assert.equal(SVM.predict([[1,1]]), -1);
+
+var json = SVM.toJSON();
+
+var SVM2 = new svm.SVM();
+
+assert.equal(SVM2.predict([[0,1]]), -1);
+
+SVM2.fromJSON(json, svm.makeRbfKernel(0.5));
+
+assert.equal(SVM2.predict([[0,0]]), -1);
+assert.equal(SVM2.predict([[0,1]]), 1);
+assert.equal(SVM2.predict([[1,0]]), 1);
+assert.equal(SVM2.predict([[1,1]]), -1);


### PR DESCRIPTION
There's no way to JSON-ify the kernel function used to train an SVM, so `fromJSON()` needs a way to let you specify a kernel function.

This patch adds a second argument to `fromJSON()` which is the kernel function. It also adds a node.js test to the `test` directory.

_Side question_: I really like the `toJSON()/fromJSON()` functions because I can train an SVM, store the trained state in JSON and load it in later in another place. But it looks like it has to store all the training data and labels as well. The problem is I have thousands of pieces of ~1000 dimension data, so storing that isn't ideal.

Is there any way avoid storing the training data and labels? Does the SVM always need the original data when it's predicting?
