### PR TITLE
add 'memoize' option to cache kernel computations

### DIFF
--- a/lib/svm.js
+++ b/lib/svm.js
@@ -63,6 +63,18 @@ var svmjs = (function(exports){
       this.b = 0.0;
       this.usew_ = false; // internal efficiency flag
 
+      // Cache kernel computations to avoid expensive recomputation.
+      // This could use too much memory if N is large.
+      if (options.memoize) {
+        this.kernelResults = new Array(N);
+        for (var i=0;i<N;i++) {
+          this.kernelResults[i] = new Array(N);
+          for (var j=0;j<N;j++) {
+            this.kernelResults[i][j] = kernel(data[i],data[j]);
+          }
+        }
+      }
+
       // run SMO algorithm
       var iter = 0;
       var passes = 0;
@@ -93,8 +105,8 @@ var svmjs = (function(exports){
             }
             
             if(Math.abs(L - H) < 1e-4) continue;
-            
-            var eta = 2*kernel(data[i],data[j]) - kernel(data[i],data[i]) - kernel(data[j],data[j]);
+
+            var eta = 2*this.kernelResult(i,j) - this.kernelResult(i,i) - this.kernelResult(j,j);
             if(eta >= 0) continue;
             
             // compute new alpha_j and clip it inside [0 C]x[0 C] box
@@ -108,10 +120,10 @@ var svmjs = (function(exports){
             this.alpha[i] = newai;
             
             // update the bias term
-            var b1 = this.b - Ei - labels[i]*(newai-ai)*kernel(data[i],data[i])
-                     - labels[j]*(newaj-aj)*kernel(data[i],data[j]);
-            var b2 = this.b - Ej - labels[i]*(newai-ai)*kernel(data[i],data[j])
-                     - labels[j]*(newaj-aj)*kernel(data[j],data[j]);
+            var b1 = this.b - Ei - labels[i]*(newai-ai)*this.kernelResult(i,i)
+                     - labels[j]*(newaj-aj)*this.kernelResult(i,j);
+            var b2 = this.b - Ej - labels[i]*(newai-ai)*this.kernelResult(i,j)
+                     - labels[j]*(newaj-aj)*this.kernelResult(j,j);
             this.b = 0.5*(b1+b2);
             if(newai > 0 && newai < C) this.b= b1;
             if(newaj > 0 && newaj < C) this.b= b2;
@@ -219,7 +231,14 @@ var svmjs = (function(exports){
       return margins;
       
     },
-    
+
+    kernelResult: function(i, j) {
+      if (this.kernelResults) {
+        return this.kernelResults[i][j];
+      }
+      return this.kernel(this.data[i], this.data[j]);
+    },
+
     // data is NxD array. Returns array of 1 or -1, predictions
     predict: function(data) {
       var margs = this.margins(data);


### PR DESCRIPTION
This tries to speed up training by caching the kernel computation for each data pair to avoid re-computation. To enable it add `memoize: true` to the training options.

I tried it on ~1000 vectors of length ~1000 and the speedup was about 10% on both linear and rbf kernels, so not a huge amount.
